### PR TITLE
DEVOPS-15838: add checksum header for S3 storage

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -387,6 +387,10 @@ module Paperclip
             write_options[:metadata] = @s3_metadata unless @s3_metadata.empty?
             write_options.merge!(@s3_headers)
 
+            sha256_checksum = Digest::SHA256.hexdigest(File.read(file.path))
+            encoded_sha256_checksum = Base64.encode64([sha256_checksum].pack("H*")).strip
+            write_options[:checksum_sha256] = encoded_sha256_checksum # Required for FIPS (SHA256) and object locking (checksum)
+
             s3_object(style).upload_file(file.path, write_options)
           rescue ::Aws::S3::Errors::NoSuchBucket
             create_bucket


### PR DESCRIPTION
## JIRA

_Complete the URLs for the main JIRA ticket and propagation subtask._

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/DEVOPS-15838)

## Code reviewers

@jmathadu @PNarode 

## Summary of issue

- Paperclip upload to S3 fails due to missing checksum header
- The checksum header is required for Object Lock with Retention enabled
- Default MD5 checksum cannot be used due to FIPS mode
 
## Summary of change

- Overwrite the PaperClip S3 storage to add checksum SHA256 

## Testing approach

Use Control UI to upload CSV file
The file is saved to `paperclip-us-east-1-coupadev-com` bucket, which has Object Lock enabled
Here is the S3 link
https://us-east-1.console.aws.amazon.com/s3/buckets/paperclip-us-east-1-coupadev-com?region=us-east-1&bucketType=general&prefix=control-ops-qa.coupadev.com/data_sources/files/000/000/112/original/&showversions=false


[1]: https://coupadev.atlassian.net/wiki/display/CD/Guidelines+for+Risk+Levels
[2]: https://coupadev.atlassian.net/wiki/display/CD/Code+Review+Checklist
[3]: https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments
[4]: https://github.com/blog/821
